### PR TITLE
Add unit tests covering IPC handlers and renderer utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A modern Electron-based GUI for CTrace static analysis tool",
   "main": "src/main.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "start": "electron .",
     "dist": "electron-builder",
     "dist:win": "electron-builder --win",

--- a/tests/ctraceHandlers.test.js
+++ b/tests/ctraceHandlers.test.js
@@ -1,0 +1,116 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const os = require('node:os');
+const fsPromises = require('node:fs/promises');
+const Module = require('node:module');
+const { EventEmitter } = require('node:events');
+
+function withModuleMocks(mocks, callback) {
+  const originalLoad = Module._load;
+  Module._load = function (request, parent, isMain) {
+    if (Object.prototype.hasOwnProperty.call(mocks, request)) {
+      return mocks[request];
+    }
+    return originalLoad.apply(this, arguments);
+  };
+  try {
+    return callback();
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+function createChildProcess({ stdout = '', stderr = '', code = 0, error = null }) {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = () => { child.killed = true; };
+
+  process.nextTick(() => {
+    if (error) {
+      child.emit('error', error instanceof Error ? error : new Error(error));
+      return;
+    }
+    if (stdout) {
+      child.stdout.emit('data', Buffer.from(stdout));
+    }
+    if (stderr) {
+      child.stderr.emit('data', Buffer.from(stderr));
+    }
+    child.emit('close', code);
+  });
+
+  return child;
+}
+
+test('run-ctrace handler reports missing binary when access fails', async (t) => {
+  const handlers = new Map();
+  const electronStub = {
+    ipcMain: {
+      handle: (channel, handler) => handlers.set(channel, handler)
+    }
+  };
+
+  const spawnStub = t.mock.fn(() => createChildProcess({ code: 0 }));
+
+  const { setupCtraceHandlers } = withModuleMocks({
+    electron: electronStub,
+    'child_process': { spawn: (...args) => spawnStub(...args) }
+  }, () => {
+    const modulePath = path.join(__dirname, '../src/main/ipc/ctraceHandlers.js');
+    delete require.cache[modulePath];
+    return require(modulePath);
+  });
+
+  const accessMock = t.mock.method(fsPromises, 'access', async () => {
+    throw new Error('not found');
+  });
+
+  const platformMock = t.mock.method(os, 'platform', () => 'linux');
+
+  setupCtraceHandlers();
+  const response = await handlers.get('run-ctrace')(null, []);
+
+  assert.strictEqual(response.success, false);
+  assert.ok(response.error.includes('ctrace binary not found'));
+  assert.strictEqual(spawnStub.mock.calls.length, 0);
+
+  accessMock.mock.restore();
+  platformMock.mock.restore();
+});
+
+test('run-ctrace handler executes binary and returns output', async (t) => {
+  const handlers = new Map();
+  const electronStub = {
+    ipcMain: {
+      handle: (channel, handler) => handlers.set(channel, handler)
+    }
+  };
+
+  const spawnStub = t.mock.fn(() => createChildProcess({ stdout: 'analysis complete', code: 0 }));
+
+  const { setupCtraceHandlers } = withModuleMocks({
+    electron: electronStub,
+    'child_process': { spawn: (...args) => spawnStub(...args) }
+  }, () => {
+    const modulePath = path.join(__dirname, '../src/main/ipc/ctraceHandlers.js');
+    delete require.cache[modulePath];
+    return require(modulePath);
+  });
+
+  const accessMock = t.mock.method(fsPromises, 'access', async () => {});
+  const platformMock = t.mock.method(os, 'platform', () => 'linux');
+
+  setupCtraceHandlers();
+  const response = await handlers.get('run-ctrace')(null, ['--version']);
+
+  assert.deepStrictEqual(response, { success: true, output: 'analysis complete', exitCode: 0 });
+  assert.ok(spawnStub.mock.calls.length >= 1);
+  const firstCall = spawnStub.mock.calls[0].arguments;
+  assert.ok(firstCall[0].includes('bin/ctrace'));
+
+  accessMock.mock.restore();
+  platformMock.mock.restore();
+});
+

--- a/tests/editorHandlers.test.js
+++ b/tests/editorHandlers.test.js
@@ -1,0 +1,61 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const Module = require('node:module');
+
+function withModuleMocks(mocks, callback) {
+  const originalLoad = Module._load;
+  Module._load = function (request, parent, isMain) {
+    if (Object.prototype.hasOwnProperty.call(mocks, request)) {
+      return mocks[request];
+    }
+    return originalLoad.apply(this, arguments);
+  };
+  try {
+    return callback();
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+test('open-editor uses platform specific commands', async (t) => {
+  const handlers = new Map();
+  const electronStub = {
+    ipcMain: {
+      on: (channel, listener) => handlers.set(channel, listener)
+    }
+  };
+
+  const execStub = t.mock.fn((command, cb) => cb && cb(null));
+
+  const modulePath = path.join(__dirname, '../src/main/ipc/editorHandlers.js');
+  const { setupEditorHandlers } = withModuleMocks({
+    electron: electronStub,
+    'child_process': { exec: (...args) => execStub(...args) }
+  }, () => {
+    delete require.cache[modulePath];
+    return require(modulePath);
+  });
+
+  const originalPlatform = process.platform;
+
+  setupEditorHandlers();
+  assert.ok(handlers.has('open-editor'));
+
+  const listener = handlers.get('open-editor');
+
+  Object.defineProperty(process, 'platform', { value: 'linux' });
+  listener();
+  assert.strictEqual(execStub.mock.calls.at(-1).arguments[0], 'x-terminal-emulator -e nano');
+
+  Object.defineProperty(process, 'platform', { value: 'darwin' });
+  listener();
+  assert.strictEqual(execStub.mock.calls.at(-1).arguments[0], 'open -a TextEdit');
+
+  Object.defineProperty(process, 'platform', { value: 'win32' });
+  listener();
+  assert.strictEqual(execStub.mock.calls.at(-1).arguments[0], 'notepad');
+
+  Object.defineProperty(process, 'platform', { value: originalPlatform });
+});
+

--- a/tests/emojiTest.test.js
+++ b/tests/emojiTest.test.js
@@ -1,0 +1,42 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const os = require('node:os');
+
+const modulePath = path.join(__dirname, '../src/renderer/utils/emojiTest.js');
+
+test('testEmojiSupport inspects DOM and returns metadata', () => {
+  const originalPlatform = os.platform();
+  const platformMock = test.mock.method(os, 'platform', () => 'testos');
+
+  const createdElements = [];
+  const bodyChildren = [];
+
+  global.document = {
+    createElement: () => {
+      const element = { style: {}, textContent: '' };
+      createdElements.push(element);
+      return element;
+    },
+    body: {
+      appendChild: (el) => bodyChildren.push({ type: 'append', el }),
+      removeChild: (el) => bodyChildren.push({ type: 'remove', el })
+    }
+  };
+  global.window = {
+    getComputedStyle: () => ({ fontFamily: 'Mock Font' })
+  };
+
+  delete require.cache[modulePath];
+  const { testEmojiSupport } = require(modulePath);
+
+  const result = testEmojiSupport();
+  assert.strictEqual(result.platform, 'testos');
+  assert.ok(result.supportedEmojis.includes('📁'));
+  assert.strictEqual(result.fontFamily, 'Mock Font');
+  assert.strictEqual(createdElements.length, 1);
+  assert.deepStrictEqual(bodyChildren.map((entry) => entry.type), ['append', 'remove']);
+
+  platformMock.mock.restore();
+});
+

--- a/tests/fileHandlers.test.js
+++ b/tests/fileHandlers.test.js
@@ -1,0 +1,132 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const fsPromises = require('node:fs/promises');
+const Module = require('node:module');
+const { EventEmitter } = require('node:events');
+
+function withModuleMocks(mocks, callback) {
+  const originalLoad = Module._load;
+  Module._load = function (request, parent, isMain) {
+    if (Object.prototype.hasOwnProperty.call(mocks, request)) {
+      return mocks[request];
+    }
+    return originalLoad.apply(this, arguments);
+  };
+  try {
+    return callback();
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+test('open-folder-dialog handler returns tree and starts watcher', async (t) => {
+  const handlers = new Map();
+  const recorded = { watchCalls: 0 };
+  const mainWindow = {
+    webContents: {
+      send: t.mock.fn()
+    }
+  };
+
+  const electronStub = {
+    ipcMain: {
+      handle: (channel, handler) => handlers.set(channel, handler),
+      on: () => {}
+    },
+    dialog: {
+      showOpenDialog: () => Promise.resolve({ canceled: false, filePaths: ['/workspace/project'] }),
+      showSaveDialog: () => Promise.resolve({ canceled: false, filePath: '/workspace/save.txt' })
+    }
+  };
+
+  const fileUtilsStub = {
+    buildFileTree: async (folderPath) => [{ name: 'file.txt', path: `${folderPath}/file.txt`, type: 'file' }],
+    detectFileEncoding: async () => ({ isUTF8: true, size: 10, buffer: Buffer.from('hello world') }),
+    searchInDirectory: async () => [{ file: '/workspace/project/file.txt', content: 'match' }],
+    FILE_SIZE_LIMIT: 5
+  };
+
+  const chokidarStub = {
+    watch: () => {
+      recorded.watchCalls++;
+      const emitter = new EventEmitter();
+      emitter.on = function (event, listener) {
+        EventEmitter.prototype.on.call(this, event, listener);
+        return this;
+      };
+      emitter.close = () => { emitter.closed = true; };
+      return emitter;
+    }
+  };
+
+  const modulePath = path.join(__dirname, '../src/main/ipc/fileHandlers.js');
+  const mocks = {
+    electron: electronStub,
+    chokidar: chokidarStub,
+    '../utils/fileUtils': fileUtilsStub
+  };
+
+  const writeFileMock = t.mock.method(fsPromises, 'writeFile', async () => {});
+
+  const { setupFileHandlers } = withModuleMocks(mocks, () => {
+    delete require.cache[modulePath];
+    return require(modulePath);
+  });
+
+  setupFileHandlers(mainWindow);
+  assert.ok(handlers.has('open-folder-dialog'));
+
+  const response = await handlers.get('open-folder-dialog')();
+  assert.deepStrictEqual(response, {
+    success: true,
+    folderPath: '/workspace/project',
+    fileTree: [{ name: 'file.txt', path: '/workspace/project/file.txt', type: 'file' }]
+  });
+  assert.strictEqual(recorded.watchCalls, 1);
+
+  const saveResponse = await handlers.get('save-file')(null, '/workspace/project/file.txt', 'updated');
+  assert.deepStrictEqual(saveResponse, { success: true });
+  assert.strictEqual(writeFileMock.mock.calls.length > 0, true);
+
+  const searchResponse = await handlers.get('search-in-files')(null, 'match', '/workspace/project');
+  assert.deepStrictEqual(searchResponse, { success: true, results: [{ file: '/workspace/project/file.txt', content: 'match' }] });
+});
+
+test('open-file-dialog returns encoding warning when detectFileEncoding rejects UTF-8', async (t) => {
+  const handlers = new Map();
+  const electronStub = {
+    ipcMain: {
+      handle: (channel, handler) => handlers.set(channel, handler),
+      on: () => {}
+    },
+    dialog: {
+      showOpenDialog: () => Promise.resolve({ canceled: false, filePaths: ['/workspace/warn.bin'] }),
+      showSaveDialog: () => Promise.resolve({ canceled: true })
+    }
+  };
+
+  const fileUtilsStub = {
+    buildFileTree: async () => [],
+    detectFileEncoding: async () => ({ isUTF8: false, size: 20, buffer: Buffer.alloc(0) }),
+    searchInDirectory: async () => [],
+    FILE_SIZE_LIMIT: 5
+  };
+
+  const modulePath = path.join(__dirname, '../src/main/ipc/fileHandlers.js');
+
+  const { setupFileHandlers } = withModuleMocks({
+    electron: electronStub,
+    chokidar: { watch: () => new EventEmitter() },
+    '../utils/fileUtils': fileUtilsStub
+  }, () => {
+    delete require.cache[modulePath];
+    return require(modulePath);
+  });
+
+  setupFileHandlers({ webContents: { send: () => {} } });
+  const response = await handlers.get('open-file-dialog')();
+  assert.strictEqual(response.warning, 'encoding');
+  assert.strictEqual(response.success, true);
+});
+

--- a/tests/fileTypeUtils.test.js
+++ b/tests/fileTypeUtils.test.js
@@ -1,0 +1,33 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const modulePath = path.join(__dirname, '../src/renderer/utils/fileTypeUtils.js');
+delete require.cache[modulePath];
+const fileTypeUtils = require(modulePath);
+
+const { detectFileType, updateFileTypeStatus, getFileIcon, formatFileSize } = fileTypeUtils;
+
+test('detectFileType categorizes extensions', () => {
+  assert.strictEqual(detectFileType('main.c'), 'C');
+  assert.strictEqual(detectFileType('main.cpp'), 'C++');
+  assert.strictEqual(detectFileType('script.py'), 'Python');
+  assert.strictEqual(detectFileType('README.md'), 'Markdown');
+  assert.strictEqual(detectFileType(''), 'Plain Text');
+});
+
+test('updateFileTypeStatus writes to DOM element when present', () => {
+  const element = { textContent: '' };
+  global.document = { getElementById: () => element };
+  updateFileTypeStatus('example.js');
+  assert.strictEqual(element.textContent, 'JavaScript');
+});
+
+test('getFileIcon returns emoji and formatFileSize formats numbers', () => {
+  assert.strictEqual(getFileIcon('file.js'), '🟨');
+  assert.strictEqual(getFileIcon('unknown.xyz'), '📄');
+  assert.strictEqual(formatFileSize(0), '0 Bytes');
+  assert.strictEqual(formatFileSize(1024), '1 KB');
+  assert.strictEqual(formatFileSize(1024 * 1024), '1 MB');
+});
+

--- a/tests/fileUtils.test.js
+++ b/tests/fileUtils.test.js
@@ -1,0 +1,87 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const os = require('node:os');
+
+const {
+  isValidUTF8,
+  buildFileTree,
+  searchInDirectory,
+  detectFileEncoding
+} = require('../src/main/utils/fileUtils');
+
+async function withTempDir(callback) {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'file-utils-test-'));
+  try {
+    return await callback(tempDir);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+test('isValidUTF8 returns true for ASCII text', () => {
+  const buffer = Buffer.from('Hello, world!', 'utf8');
+  assert.strictEqual(isValidUTF8(buffer), true);
+});
+
+test('isValidUTF8 returns true for empty buffer', () => {
+  const buffer = Buffer.alloc(0);
+  assert.strictEqual(isValidUTF8(buffer), true);
+});
+
+test('isValidUTF8 returns false when null byte ratio exceeds threshold', () => {
+  const buffer = Buffer.alloc(200, 1);
+  for (let i = 0; i < 50; i++) {
+    buffer[i] = 0;
+  }
+  assert.strictEqual(isValidUTF8(buffer), false);
+});
+
+test('buildFileTree lists directories before files and skips ignored entries', async () => {
+  await withTempDir(async (tempDir) => {
+    await fs.mkdir(path.join(tempDir, 'visibleDir'));
+    await fs.writeFile(path.join(tempDir, 'visibleDir', 'inner.txt'), 'content');
+    await fs.writeFile(path.join(tempDir, 'visibleFile.txt'), 'content');
+    await fs.writeFile(path.join(tempDir, '.hiddenFile'), 'secret');
+    await fs.mkdir(path.join(tempDir, 'node_modules'));
+
+    const tree = await buildFileTree(tempDir);
+    assert.strictEqual(tree.length, 2);
+    assert.deepStrictEqual(tree.map((entry) => entry.name), ['visibleDir', 'visibleFile.txt']);
+
+    const dirEntry = tree.find((entry) => entry.type === 'directory');
+    assert.ok(dirEntry, 'expected directory entry to be present');
+    assert.deepStrictEqual(dirEntry.children.map((child) => child.name), ['inner.txt']);
+  });
+});
+
+test('searchInDirectory finds matches and respects maximum results', async () => {
+  await withTempDir(async (tempDir) => {
+    await fs.writeFile(path.join(tempDir, 'first.txt'), 'TODO: write tests\nNothing here');
+    await fs.mkdir(path.join(tempDir, 'subdir'));
+    await fs.writeFile(path.join(tempDir, 'subdir', 'second.txt'), 'Line 1\nSecond TODO item');
+    await fs.writeFile(path.join(tempDir, 'subdir', 'third.txt'), 'TODO once more');
+
+    const results = await searchInDirectory(tempDir, 'TODO', 2);
+    assert.strictEqual(results.length, 2);
+    results.forEach((result) => {
+      assert.ok(result.content.includes('TODO'));
+      assert.ok(result.file.endsWith('.txt'));
+    });
+  });
+});
+
+test('detectFileEncoding reads UTF-8 files', async () => {
+  await withTempDir(async (tempDir) => {
+    const filePath = path.join(tempDir, 'hello.txt');
+    const content = 'Hello, world!';
+    await fs.writeFile(filePath, content, 'utf8');
+
+    const info = await detectFileEncoding(filePath);
+    assert.strictEqual(info.isUTF8, true);
+    assert.strictEqual(info.size, Buffer.byteLength(content));
+    assert.ok(Buffer.isBuffer(info.buffer));
+    assert.strictEqual(info.buffer.toString('utf8'), content);
+  });
+});

--- a/tests/wslTest.test.js
+++ b/tests/wslTest.test.js
@@ -1,0 +1,72 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const os = require('node:os');
+const childProcess = require('node:child_process');
+const { EventEmitter } = require('node:events');
+
+function loadModule() {
+  const modulePath = path.join(__dirname, '../src/main/utils/wslTest.js');
+  delete require.cache[modulePath];
+  return require(modulePath);
+}
+
+function createChild(result) {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = () => { child.killed = true; };
+
+  process.nextTick(() => {
+    if (result.stdout) {
+      child.stdout.emit('data', Buffer.from(result.stdout));
+    }
+    if (result.stderr) {
+      child.stderr.emit('data', Buffer.from(result.stderr));
+    }
+    if (result.error) {
+      child.emit('error', new Error(result.error));
+    } else {
+      child.emit('close', result.code ?? 0);
+    }
+  });
+
+  return child;
+}
+
+test('testWSLAndCTrace resolves immediately on non-Windows platforms', async (t) => {
+  const platformMock = t.mock.method(os, 'platform', () => 'linux');
+  const spawnMock = t.mock.method(childProcess, 'spawn');
+  const { testWSLAndCTrace } = loadModule();
+
+  const result = await testWSLAndCTrace();
+  assert.strictEqual(result, true);
+  assert.strictEqual(spawnMock.mock.calls.length, 0);
+
+  platformMock.mock.restore();
+  spawnMock.mock.restore();
+});
+
+test('testWSLAndCTrace completes checks on Windows when commands succeed', async (t) => {
+  const platformMock = t.mock.method(os, 'platform', () => 'win32');
+  const spawnSequence = [
+    { code: 0 },
+    { stdout: 'ctrace help', code: 0 }
+  ];
+  const spawnMock = t.mock.method(childProcess, 'spawn', () => {
+    const next = spawnSequence.shift();
+    return createChild(next || {});
+  });
+
+  const { testWSLAndCTrace } = loadModule();
+  const result = await testWSLAndCTrace();
+
+  assert.strictEqual(result, true);
+  assert.strictEqual(spawnMock.mock.calls.length, 2);
+  assert.deepStrictEqual(spawnMock.mock.calls[0].arguments.slice(0, 2), ['wsl', ['--status']]);
+  assert.deepStrictEqual(spawnMock.mock.calls[1].arguments[0], 'wsl');
+
+  platformMock.mock.restore();
+  spawnMock.mock.restore();
+});
+


### PR DESCRIPTION
## Summary
- add tests for file utility encoding detection and WSL verification helper
- cover IPC handlers for file operations, ctrace, and editor commands using mocked dependencies
- exercise renderer utilities for file metadata display and emoji feature checks

## Testing
- npm test
