### PR TITLE
fix overflow for top and bottom panels

### DIFF
--- a/src/styles/diagnostics.css
+++ b/src/styles/diagnostics.css
@@ -3,6 +3,8 @@
   padding: 18px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
   background: rgba(255, 255, 255, 0.02);
+  overflow: hidden;
+  min-width: 0;
 }
 
 .section-header {
@@ -325,7 +327,9 @@
   display: flex;
   align-items: center;
   gap: 10px;
+  flex: 1;
   min-width: 0;
+  overflow: hidden;
 }
 
 .count-badge {
@@ -338,6 +342,7 @@
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  flex-shrink: 0;
 }
 
 .count-badge-clear {
@@ -349,6 +354,14 @@
   font-size: 13px;
   font-weight: 600;
   color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.severity-filter {
+  flex-shrink: 0;
 }
 
 .severity-filter select {

--- a/src/styles/menubar.css
+++ b/src/styles/menubar.css
@@ -13,6 +13,7 @@
   -webkit-app-region: no-drag;
   position: relative;
   z-index: 500;
+  overflow: hidden;
 }
 
 .menu-item {

--- a/src/styles/menubar.css
+++ b/src/styles/menubar.css
@@ -13,7 +13,6 @@
   -webkit-app-region: no-drag;
   position: relative;
   z-index: 500;
-  overflow: hidden;
 }
 
 .menu-item {

--- a/src/styles/sidebar.css
+++ b/src/styles/sidebar.css
@@ -107,6 +107,13 @@
   text-overflow: ellipsis;
 }
 
+#workspace-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
 .file-tree-folder {
   margin-left: 12px;
 }

--- a/src/styles/statusbar.css
+++ b/src/styles/statusbar.css
@@ -12,6 +12,7 @@
   font-size: 11px;
   color: var(--text-secondary);
   font-weight: 500;
+  overflow: hidden;
 }
 
 .statusbar-left,
@@ -20,6 +21,13 @@
   align-items: center;
   gap: 14px;
   min-width: 0;
+  overflow: hidden;
+}
+
+.statusbar-left > *,
+.statusbar-right > * {
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 #backend_version {


### PR DESCRIPTION
- **Diagnostics toolbar**: fixed the errors count text overlapped by the issues
  filter dropdown when the panel isn't wide enough
- **Menubar / status bar**: adds `overflow: hidden` so items clip inside
  their pill containers instead of spilling out when the sidebar or
  tools panel is dragged wide
- **Sidebar workspace name**: adds ellipsis truncation for long folder
  paths
- **Tools section**: adds `overflow: hidden` to prevent the args input
  and buttons from escaping their padding at narrow widths
